### PR TITLE
Document that the backtracking resolver is the current default

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,26 +559,22 @@ on each targeted Python environment to avoid issues.
 
 This section lists `pip-tools` features that are currently deprecated.
 
-- In future versions, the `--allow-unsafe` behavior will be enabled by
-  default. Use `--no-allow-unsafe` to keep the old behavior. It is
-  recommended to pass the `--allow-unsafe` now to adapt to the upcoming
-  change.
-- Legacy resolver is deprecated and will be removed in future versions.
-  Use `--resolver=backtracking` instead.
+- In the next major release, the `--allow-unsafe` behavior will be enabled by
+  default (https://github.com/jazzband/pip-tools/issues/989).
+  Use `--no-allow-unsafe` to keep the old behavior. It is recommended
+  to pass the `--allow-unsafe` now to adapt to the upcoming change.
+- The legacy resolver is deprecated and will be removed in future versions.
+  The new default is `--resolver=backtracking`.
 
 ### A Note on Resolvers
 
-You can choose from either the legacy or the backtracking resolver.
-The backtracking resolver is recommended, and will become the default
-with the 7.0 release.
-
-Use it now with the `--resolver=backtracking` option to `pip-compile`.
+You can choose from either default backtracking resolver or the deprecated legacy resolver.
 
 The legacy resolver will occasionally fail to resolve dependencies. The
-backtracking resolver is more robust, but can take longer to run in
-general.
+backtracking resolver is more robust, but can take longer to run in general.
 
-You can continue using the legacy resolver with `--resolver=legacy`.
+You can continue using the legacy resolver with `--resolver=legacy` although
+note that it is deprecated and will be removed in a future release.
 
 ### Versions and compatibility
 


### PR DESCRIPTION
I think updating these docs was accidentally overlooked when the https://github.com/jazzband/pip-tools/releases/tag/7.0.0 release happened.


##### Contributor checklist

- [x] Provided the tests for the changes.
- [x] Assure PR title is short, clear, and good to be included in the user-oriented changelog

##### Maintainer checklist

- [ ] Assure one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
