### PR TITLE
Remove outdated compatibility matrix from `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,23 +576,6 @@ backtracking resolver is more robust, but can take longer to run in general.
 You can continue using the legacy resolver with `--resolver=legacy` although
 note that it is deprecated and will be removed in a future release.
 
-### Versions and compatibility
-
-The table below summarizes the latest `pip-tools` versions with the required
-`pip` and Python versions. Generally, `pip-tools` supports the same Python
-versions as the required `pip` versions.
-
-| pip-tools      | pip            | Python         |
-| -------------- | -------------- | -------------- |
-| 4.5.\*         | 8.1.3 - 20.0.2 | 2.7, 3.5 - 3.8 |
-| 5.0.0 - 5.3.0  | 20.0 - 20.1.1  | 2.7, 3.5 - 3.8 |
-| 5.4.0          | 20.1 - 20.3.\* | 2.7, 3.5 - 3.8 |
-| 5.5.0          | 20.1 - 20.3.\* | 2.7, 3.5 - 3.9 |
-| 6.0.0 - 6.3.1  | 20.3 - 21.2.\* | 3.6 - 3.9      |
-| 6.4.0          | 21.2 - 21.3.\* | 3.6 - 3.10     |
-| 6.5.0 - 6.10.0 | 21.2 - 22.3.\* | 3.7 - 3.11     |
-| 6.11.0+        | 22.2+          | 3.7 - 3.11     |
-
 [jazzband]: https://jazzband.co/
 [jazzband-image]: https://jazzband.co/static/img/badge.svg
 [pypi]: https://pypi.org/project/pip-tools/


### PR DESCRIPTION
As noted in https://github.com/jazzband/pip-tools/issues/1937, this matrix is out of date now that https://github.com/jazzband/pip-tools/releases/tag/7.0.0 has shipped.

Technically it could be kept around and add some more rows, but I don't think it's worth the effort... it will always be going out of date. Instead, let the internal dep constraints within `setup.py`/`pyproject.toml` constrain what versions of `python` / `pip` are compatible with that version of `pip-tools`. Most users won't care, but those who will can access that data manually. And otherwise it'll all be smoothly resolved by package managers.

So let's just remove it altogether.

Fix: https://github.com/jazzband/pip-tools/issues/1937

##### Contributor checklist

- [ ] Included tests for the changes.
- [x] PR title is short, clear, and ready to be included in the user-facing changelog.

##### Maintainer checklist

- [ ] Verified one of these labels is present: `backwards incompatible`, `feature`, `enhancement`, `deprecation`, `bug`, `dependency`, `docs` or `skip-changelog` as they determine changelog listing.
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
